### PR TITLE
add sqlformat to dotfiles docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          python3-pip \
          python3-setuptools \
          silversearcher-ag \
+         sqlformat \
          unzip
 
 RUN mkdir /root/.dotfiles


### PR DESCRIPTION
This PR adds sqlformat to the dotfiles docker. Later we should also add LaTeX.